### PR TITLE
Update branch references from master to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 See distributed tracing working group contributing
-[docs](https://github.com/w3c/distributed-tracing-wg/blob/master/CONTRIBUTING.md)
+[docs](https://github.com/w3c/distributed-tracing-wg/blob/main/CONTRIBUTING.md)
 for a general guidance.
 
 See [Registration Entry Requirements and Update

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
 
           github: {
             repoURL: "https://github.com/w3c/trace-context-protocols-registry/",
-            branch: "master",
+            branch: "main",
           },
           otherLinks: [{
             key: 'Discussions',


### PR DESCRIPTION
The master branch was renamed to main, but some references to the master branch were not updated.
This commit updates those locations to refer to the main branch instead of master.